### PR TITLE
fix: 太字の前後にスペースを入れるルールの不具合を修正

### DIFF
--- a/.changeset/cool-yaks-run.md
+++ b/.changeset/cool-yaks-run.md
@@ -1,0 +1,5 @@
+---
+'@hiratake/textlint-rule-space-around-bold': patch
+---
+
+ドキュメントを修正

--- a/.changeset/lemon-bulldogs-heal.md
+++ b/.changeset/lemon-bulldogs-heal.md
@@ -1,0 +1,5 @@
+---
+'@hiratake/textlint-rule-space-around-bold': patch
+---
+
+太字の前後が改行の場合にもスペースが挿入される問題を修正

--- a/.changeset/quiet-adults-yawn.md
+++ b/.changeset/quiet-adults-yawn.md
@@ -1,0 +1,5 @@
+---
+'@hiratake/textlint-rule-space-around-bold': patch
+---
+
+リンクの中にある太字の前後にもスペースが挿入される問題を修正

--- a/packages/textlint-rule-space-around-bold/README.md
+++ b/packages/textlint-rule-space-around-bold/README.md
@@ -24,7 +24,10 @@ $ pnpm add -D @hiratake/textlint-rule-space-around-bold
 ```json
 {
   "rules": {
-    "@hiratake/textlint-rule-space-around-bold": true
+    "@hiratake/textlint-rule-space-around-bold": {
+      "before": true, // 太字の前にスペースを入れる
+      "after": true,  // 太字の後にスペースを入れる
+    },
   }
 }
 ```

--- a/packages/textlint-rule-space-around-bold/src/index.ts
+++ b/packages/textlint-rule-space-around-bold/src/index.ts
@@ -21,7 +21,7 @@ const reporter: TextlintRuleModule<Options> = (context, options = {}) => {
     [Syntax.Strong](node) {
       const nodeText = getSource(node)
       // 文字列の前後1文字を取得
-      const textWithPadding = getSource(node, 1, 1)
+      const textWithPadding = getSource(node, 1, 1).replace(/^\n*|\n*$/g, '')
       if (!textWithPadding) {
         return
       }

--- a/packages/textlint-rule-space-around-bold/src/index.ts
+++ b/packages/textlint-rule-space-around-bold/src/index.ts
@@ -34,7 +34,8 @@ const reporter: TextlintRuleModule<Options> = (context, options = {}) => {
         // 太字の前に文字が存在している場合のみ処理を実行
         if (allowBeforeSpace) {
           // 太字の前にスペースを入れる
-          if (beforeChar !== ' ') {
+          // リンクの中にある太字には適用しない
+          if (beforeChar !== ' ' && beforeChar !== '[') {
             report(
               node,
               new RuleError('太字の前にスペースを入れてください。', {
@@ -61,7 +62,8 @@ const reporter: TextlintRuleModule<Options> = (context, options = {}) => {
         // 太字の後に文字が存在している場合のみ処理を実行
         if (allowAfterSpace) {
           // 太字の後にスペースを入れる
-          if (afterChar !== ' ') {
+          // リンクの中にある太字には適用しない
+          if (afterChar !== ' ' && afterChar !== ']') {
             report(
               node,
               new RuleError('太字の後にスペースを入れてください。', {

--- a/packages/textlint-rule-space-around-bold/test/index-test.ts
+++ b/packages/textlint-rule-space-around-bold/test/index-test.ts
@@ -63,6 +63,13 @@ tester.run('太字の前後のスペース', rule, {
         after: true,
       },
     },
+    {
+      text: `[**リンクの中の太字**](https://example.com) の前後は無視する`,
+      options: {
+        before: true,
+        after: true,
+      },
+    },
   ],
   invalid: [
     {

--- a/packages/textlint-rule-space-around-bold/test/index-test.ts
+++ b/packages/textlint-rule-space-around-bold/test/index-test.ts
@@ -33,6 +33,36 @@ tester.run('太字の前後のスペース', rule, {
         after: true,
       },
     },
+    {
+      text: '**太字** から始まるテキストの場合は前にスペースがなくてもよい',
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: `
+**太字** から始まる新しい行のテキストの場合は前にスペースがなくてもよい`,
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: '太字で終わるテキストの場合は後にスペースが **なくてもよい**',
+      options: {
+        before: true,
+        after: true,
+      },
+    },
+    {
+      text: `太字で改行されるテキストの場合は後にスペースが **なくてもよい**
+`,
+      options: {
+        before: true,
+        after: true,
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
- 前後の文字が改行の場合にもスペースが挿入されるのを修正
- リンクの中にある太字の場合にもスペースが挿入されるのを修正
- ドキュメントにある例のオプションが `true` になっていたのを修正