### PR TITLE
build: jsファイルをesモジュールとして扱うよう変更

### DIFF
--- a/packages/social-share/package.json
+++ b/packages/social-share/package.json
@@ -33,6 +33,7 @@
       "require": "./dist/social-share.umd.js"
     }
   },
+  "type": "module",
   "dependencies": {
     "@vueuse/core": "10.6.1"
   },


### PR DESCRIPTION
- `vite` v5 への対応