### PR TITLE
fix: rssフィードにおける改行の扱いを修正

### DIFF
--- a/src/server/utils/content.ts
+++ b/src/server/utils/content.ts
@@ -50,7 +50,7 @@ export const generateContentFromAst = (
       } else if (node.tag === 'pre') {
         // コードブロック
         const code =
-          (node.props?.code as string).trim().replace(/\n/g, '\\n') || ''
+          (node.props?.code as string).trim().replace(/\n/g, '&#xA;') || ''
         content += `<${node.tag}><code>${code}</code></${node.tag}>`
         continue
       } else if (['hr', 'br'].includes(node.tag)) {


### PR DESCRIPTION
- close #1115

mainブランチのコードでは引き続きコードブロック内で改行が表現されません。これを修正するPRです。

![image](https://github.com/Hiratake/hiratake-web/assets/8929706/9b9b0209-77cb-43cd-b706-17b6a9d7149f)

---

これは pre 要素内で `\n` を用いて改行していることが問題なようで、ChatGPTに聞いたら実体参照 `&#xA;` でよさそうです。
もしくはエスケープしない改行で処理することになりそうです。
このPRでは、改行の実体参照 `&#xA;` でコードブロック内も改行できるよう対応しています。

`pnpm generate` で適当に生成してFeedlyに食わせたらうまくいきました。

![image](https://github.com/Hiratake/hiratake-web/assets/8929706/69395262-5f58-4c31-9668-17d9ca56a7e6)
