### PR TITLE
chore: 廃止されたcomponent-tags-orderをblock-orderへ置き換え

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,10 +13,7 @@ export default withNuxt({
         math: 'always',
       },
     ],
-    'vue/component-tags-order': [
-      'error',
-      { order: ['script', 'template', 'style'] },
-    ],
+    'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
   },
 }).override('nuxt/typescript/rules', {
   rules: {


### PR DESCRIPTION
`eslint-plugin-vue` v10.0.0 で `vue/component-tags-order` が廃止されている。
`vue/block-order` に置き換えられているようなので、変更する。
- https://togithub.com/vuejs/eslint-plugin-vue/releases/tag/v10.0.0
- https://eslint.vuejs.org/rules/block-order.html