### PR TITLE
fix: 重複するurlをサイトマップから除外

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -67,7 +67,15 @@ export default defineContentConfig({
         updated: z.date().optional(),
         author: z.string().optional(),
         schemaOrg: defineSchemaOrgSchema(),
-        sitemap: defineSitemapSchema(),
+        sitemap: defineSitemapSchema({
+          name: 'blog',
+          onUrl: (url) => {
+            url.loc = url.loc.replace(
+              /\/blog\/(\d{4})\/(\d{2})\/(\d{2})\/?/,
+              '/blog/$1$2$3/',
+            )
+          },
+        }),
         ogImage: defineOgImageSchema(),
         robots: defineRobotsSchema(),
       }),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -61,10 +61,7 @@ export default defineNuxtConfig({
     defaultLocale: 'ja',
     trailingSlash: true,
   },
-  sitemap: {
-    exclude: [new RegExp(/^\/blog\/\d{4}\/\d{2}\/\d{2}\/$/)],
-    zeroRuntime: true,
-  },
+  sitemap: { zeroRuntime: true },
   ui: { prose: true },
   $production: {
     scripts: {


### PR DESCRIPTION
- fix #2389 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ブログ記事のサイトマップURLを、日付を含む `/blog/YYYYMMDD/` 形式で生成するよう改善しました。
  * 日付形式のブログURLがサイトマップから正しく取得されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->